### PR TITLE
Fix relative imports

### DIFF
--- a/wilddog/async.py
+++ b/wilddog/async.py
@@ -1,6 +1,6 @@
 import multiprocessing
 
-from lazy import LazyLoadProxy
+from .lazy import LazyLoadProxy
 
 __all__ = ['process_pool']
 

--- a/wilddog/wilddog.py
+++ b/wilddog/wilddog.py
@@ -7,11 +7,11 @@ except ImportError:
 
 import json
 
-from wilddog_token_generator import create_token
-from decorators import http_connection
+from .wilddog_token_generator import create_token
+from .decorators import http_connection
 
-from async import process_pool
-from jsonutil import JSONEncoder
+from .async import process_pool
+from .jsonutil import JSONEncoder
 
 __all__ = ['WilddogAuthentication', 'WilddogApplication']
 


### PR DESCRIPTION
I got `ImportError: No module named 'lazy'` using the client library.